### PR TITLE
iOS 13 fixes

### DIFF
--- a/CloudFivePush.podspec
+++ b/CloudFivePush.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "CloudFivePush"
-  s.version          = "0.10.0"
+  s.version          = "0.11.0"
   s.summary          = "iOS client library for receiving push notifications from cloudfiveapp.com."
   s.description      = <<-DESC
                        Easy push notifications via https://push.cloudfiveapp.com.  Just include this Pod in your iOS


### PR DESCRIPTION
- fix device token generation on iOS 13
- add url encoding for request parameters
- remove handing push in foreground (it was using deprecated UIAlertView, app was crashing)